### PR TITLE
Mahalanobis match size fix

### DIFF
--- a/R/pm_helpers_r.R
+++ b/R/pm_helpers_r.R
@@ -248,6 +248,10 @@ perform_refinement <- function(lag, time.id, unit.id, treatment, refinement.meth
       msets <- handle_ps_match(just.ps.sets, msets, refinement.method, verbose, size.match)
       attr(msets, "max.match.size") <- size.match
     }
+    if(refinement.method == "mahalanobis")
+    {
+      attr(msets, "max.match.size") <- size.match
+    }
   }
   t.attributes <- attributes(msets)[names(attributes(msets)) != "names"]
   msets <- c(msets, e.sets)

--- a/R/pm_helpers_r.R
+++ b/R/pm_helpers_r.R
@@ -248,10 +248,10 @@ perform_refinement <- function(lag, time.id, unit.id, treatment, refinement.meth
       msets <- handle_ps_match(just.ps.sets, msets, refinement.method, verbose, size.match)
       attr(msets, "max.match.size") <- size.match
     }
-    if(refinement.method == "mahalanobis")
-    {
-      attr(msets, "max.match.size") <- size.match
-    }
+  }
+  if(refinement.method == "mahalanobis")
+  {
+    attr(msets, "max.match.size") <- size.match
   }
   t.attributes <- attributes(msets)[names(attributes(msets)) != "names"]
   msets <- c(msets, e.sets)


### PR DESCRIPTION
I noticed a bug whereby panelmatch objects created with `PanelMatch` refined using Mahalanobis distance were missing the `max.match.size` attribute. 

## Bug

```r
## Using CRAN's PanelMatch v2.0.1

PM.results.none <- PanelMatch(lag = 4, time.id = "year", unit.id = "wbcode2", 
                              treatment = "dem", refinement.method = "none", 
                              data = dem, match.missing = TRUE, 
                              size.match = 5, qoi = "att", outcome.var = "y",
                              lead = 0:4, forbid.treatment.reversal = FALSE, 
                              use.diagonal.variance.matrix = TRUE)
#Extract the matched.set object
msets.none <- PM.results.none$att

#Call PanelMatch with refinement
PM.results.maha <- PanelMatch(lag = 4, time.id = "year", unit.id = "wbcode2", 
                              treatment = "dem", refinement.method = "mahalanobis", 
                              # use Mahalanobis distance 
                              data = dem, match.missing = TRUE, 
                              covs.formula = ~ tradewb, 
                              size.match = 5, qoi = "att" , outcome.var = "y",
                              lead = 0:4, forbid.treatment.reversal = FALSE, 
                              use.diagonal.variance.matrix = TRUE)

msets.maha <- PM.results.maha$att

PM.results.psm <- PanelMatch(lag = 4, time.id = "year", unit.id = "wbcode2", 
                              treatment = "dem", refinement.method = "ps.match", 
                              # use Mahalanobis distance 
                              data = dem, match.missing = TRUE, 
                              covs.formula = ~ tradewb, 
                              size.match = 5, qoi = "att" , outcome.var = "y",
                              lead = 0:4, forbid.treatment.reversal = FALSE, 
                              use.diagonal.variance.matrix = TRUE)


msets.psm <- PM.results.psm$att

attr(msets.none, "max.match.size")
#> NULL

attr(msets.psm, "max.match.size")
#> 5

attr(msets.maha, "max.match.size")
#> NULL # <---- This should be five

```

## prestevez/PanelMatch@mahalanobis-match-size-fix

I noticed that the attribute was not set in the helper function `perform_refinement`, so this was added toward the end of the function.

```r
# Call PanelMatch without any refinement
PM.results.none <- PanelMatch(lag = 4, time.id = "year", unit.id = "wbcode2", 
                              treatment = "dem", refinement.method = "none", 
                              data = dem, match.missing = TRUE, 
                              size.match = 5, qoi = "att", outcome.var = "y",
                              lead = 0:4, forbid.treatment.reversal = FALSE, 
                              use.diagonal.variance.matrix = TRUE)
#Extract the matched.set object
msets.none <- PM.results.none$att

#Call PanelMatch with refinement
PM.results.maha <- PanelMatch(lag = 4, time.id = "year", unit.id = "wbcode2", 
                              treatment = "dem", refinement.method = "mahalanobis", 
                              # use Mahalanobis distance 
                              data = dem, match.missing = TRUE, 
                              covs.formula = ~ tradewb, 
                              size.match = 5, qoi = "att" , outcome.var = "y",
                              lead = 0:4, forbid.treatment.reversal = FALSE, 
                              use.diagonal.variance.matrix = TRUE)

msets.maha <- PM.results.maha$att

PM.results.psm <- PanelMatch(lag = 4, time.id = "year", unit.id = "wbcode2", 
                              treatment = "dem", refinement.method = "ps.match", 
                              # use Mahalanobis distance 
                              data = dem, match.missing = TRUE, 
                              covs.formula = ~ tradewb, 
                              size.match = 5, qoi = "att" , outcome.var = "y",
                              lead = 0:4, forbid.treatment.reversal = FALSE, 
                              use.diagonal.variance.matrix = TRUE)


msets.psm <- PM.results.psm$att

attr(msets.none, "max.match.size")
#> NULL

attr(msets.psm, "max.match.size")
#> 5

attr(msets.maha, "max.match.size")
#> 5 # <---- Correct attribute

```
